### PR TITLE
Use the right-most bytes for TraceId.

### DIFF
--- a/exporter/src/main/java/com/lightstep/opentelemetry/exporter/Adapter.java
+++ b/exporter/src/main/java/com/lightstep/opentelemetry/exporter/Adapter.java
@@ -252,9 +252,12 @@ final class Adapter {
   }
 
   private static ByteString toByteString(TraceId traceId) {
-    byte[] traceIdBytes = new byte[TraceId.getSize()];
+    int traceIdSize = TraceId.getSize();
+    byte[] traceIdBytes = new byte[traceIdSize];
     traceId.copyBytesTo(traceIdBytes, 0);
-    return ByteString.copyFrom(traceIdBytes);
+    // Use the 64 least significant bits, represented by the right-most
+    // 8 bytes. See https://github.com/openzipkin/b3-propagation#traceid-1
+    return ByteString.copyFrom(traceIdBytes, traceIdSize / 2, traceIdSize / 2);
   }
 
   private static ByteString toByteString(SpanId spanId) {

--- a/exporter/src/test/java/com/lightstep/opentelemetry/exporter/AdapterTest.java
+++ b/exporter/src/test/java/com/lightstep/opentelemetry/exporter/AdapterTest.java
@@ -34,9 +34,9 @@ import org.junit.Test;
 
 public class AdapterTest {
   private static final String LINK_TRACE_ID =
-      "39431247078c75c1af46e0665b912ea9"; // 4126161779880129985
+      "463ac35c9f6413ad48485a3953bb6124"; // 5208512171318403364L (trimmed)
   private static final String LINK_SPAN_ID = "0000000000fed456"; // 16700502
-  private static final String TRACE_ID = "39431247078c75c1af46e0665b912ea9"; // 4126161779880129985
+  private static final String TRACE_ID = "463ac35c9f6413ad48485a3953bb6124"; // 5208512171318403364L (trimmed)
   private static final String SPAN_ID = "0000000000def456"; // 14611542
   private static final String PARENT_SPAN_ID = "0000000000aef789"; // 11466633
 
@@ -94,7 +94,7 @@ public class AdapterTest {
     boolean found = false;
     for (Reference spanRef : lightStepSpan.getReferencesList()) {
       if (Relationship.FOLLOWS_FROM.equals(spanRef.getRelationship())) {
-        assertEquals(4126161779880129985L, spanRef.getSpanContext().getTraceId());
+        assertEquals(5208512171318403364L, spanRef.getSpanContext().getTraceId());
         assertEquals(16700502, spanRef.getSpanContext().getSpanId());
         found = true;
       }
@@ -106,7 +106,7 @@ public class AdapterTest {
     boolean found = false;
     for (Reference spanRef : lightStepSpan.getReferencesList()) {
       if (Reference.Relationship.CHILD_OF.equals(spanRef.getRelationship())) {
-        assertEquals(4126161779880129985L, spanRef.getSpanContext().getTraceId());
+        assertEquals(5208512171318403364L, spanRef.getSpanContext().getTraceId());
         assertEquals(11466633, spanRef.getSpanContext().getSpanId());
         found = true;
       }
@@ -140,7 +140,7 @@ public class AdapterTest {
     final com.lightstep.tracer.grpc.Span lightstepSpan = Adapter.toLightstepSpan(span,
         new ArrayList<KeyValue>());
 
-    assertEquals(4126161779880129985L, lightstepSpan.getSpanContext().getTraceId());
+    assertEquals(5208512171318403364L, lightstepSpan.getSpanContext().getTraceId());
     assertEquals(14611542, lightstepSpan.getSpanContext().getSpanId());
 
     assertEquals("GET /api/endpoint", lightstepSpan.getOperationName());
@@ -264,7 +264,7 @@ public class AdapterTest {
 
     // verify
     assertEquals(14611542, spanRef.getSpanContext().getSpanId());
-    assertEquals(4126161779880129985L, spanRef.getSpanContext().getTraceId());
+    assertEquals(5208512171318403364L, spanRef.getSpanContext().getTraceId());
     assertEquals(Reference.Relationship.FOLLOWS_FROM, spanRef.getRelationship());
   }
 
@@ -293,9 +293,9 @@ public class AdapterTest {
   public void testTraceIdToLong() {
     final TraceId traceId = TraceId.fromLowerBase16(TRACE_ID, 0);
     final long traceIdLong = Adapter.traceIdToLong(traceId);
-    assertEquals(4126161779880129985L, traceIdLong);
+    assertEquals(5208512171318403364L, traceIdLong);
 
-    final TraceId traceId2 = new TraceId(123456789L, 0L);
+    final TraceId traceId2 = new TraceId(0L, 123456789L);
     final long traceIdLong2 = Adapter.traceIdToLong(traceId2);
     assertEquals(123456789L, traceIdLong2);
   }

--- a/exporter/src/test/java/com/lightstep/opentelemetry/exporter/LightstepSpanExporterTest.java
+++ b/exporter/src/test/java/com/lightstep/opentelemetry/exporter/LightstepSpanExporterTest.java
@@ -41,7 +41,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(JUnitParamsRunner.class)
 public class LightstepSpanExporterTest {
-  private static final String TRACE_ID = "39431247078c75c1af46e0665b912ea9";
+  private static final String TRACE_ID = "463ac35c9f6413ad48485a3953bb6124";
   private static final String SPAN_ID = "1213141516171819";
 
   @Rule
@@ -117,7 +117,7 @@ public class LightstepSpanExporterTest {
 
     final SpanContext spanContext = span.getSpanContext();
     assertEquals(1302406798037686297L, spanContext.getSpanId());
-    assertEquals(4126161779880129985L, spanContext.getTraceId());
+    assertEquals(5208512171318403364L, spanContext.getTraceId()); // trimmed id.
   }
 
   public String[] getServiceVersions() {


### PR DESCRIPTION
Instead of the left-most ones.