### PR TITLE
upgrade opentelemetry to 0.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <maven.compiler.target>1.7</maven.compiler.target>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <opentelemetry.version>0.6.0</opentelemetry.version>
+    <opentelemetry.version>0.7.0</opentelemetry.version>
     <grpc.version>1.28.0</grpc.version>
     <protobuf.version>3.11.4</protobuf.version>
     <powermock.version>2.0.7</powermock.version>


### PR DESCRIPTION
haven't seen any bugs using 0.6.0 with otel auto instrumentation 0.7.0, but best to keep it up to date.